### PR TITLE
/var/log/php dir not writeable by webapp user

### DIFF
--- a/.ebextensions/01_setup.config
+++ b/.ebextensions/01_setup.config
@@ -15,6 +15,8 @@ commands:
     command: chkconfig nginx on
   040_php_fpm_boot:
     command: chkconfig php-fpm on
+  050_php_error_log_perms:
+    command: chown -R webapp /var/log/php-fpm
 
 ## Update the Elasticbeanstalk environment and config files
 container_commands:


### PR DESCRIPTION
During my time testing this configuration (its working great btw, thanks for this) I found that the configured www-error.log file was not being created in /var/log/php/7.1

This PR chown's /var/log/php to be owned by the webapp user so this file is created