### PR TITLE
Make /var/log/nginx world readable.

### DIFF
--- a/.ebextensions/01_setup.config
+++ b/.ebextensions/01_setup.config
@@ -17,10 +17,12 @@ commands:
     command: chkconfig php-fpm on
   050_create_log_dirs:
     command: mkdir -p /var/log/nginx/healthd /var/log/nginx/rotated /var/log/php-fpm/7.1/rotated
-  060_php_log_perms:
+  060_php_log_ownership:
     command: chown -R webapp. /var/log/php-fpm
-  070_nginx_log_perms:
+  070_nginx_log_ownership:
     command: chown -R nginx. /var/log/nginx
+  080_nginx_log_perms:
+    command: chmod 755 /var/log/nginx
 
 ## Update the Elasticbeanstalk environment and config files
 container_commands:


### PR DESCRIPTION
Hi Rick,

I noticed some errors in the `/var/log/healthd/daemon.log` file recently. The default `nginx` setup has `/var/log/nginx` permissions set to 700. This PR changes them to 755, so the `healthd` user can read the logs.

Thanks! 